### PR TITLE
Fix category boolean updates

### DIFF
--- a/app/routes_categories.py
+++ b/app/routes_categories.py
@@ -34,9 +34,9 @@ def init_categories_routes(app):
             category.name = request.form.get('name', category.name)
             category.symbol = request.form.get('symbol', category.symbol)
             category.color_hex = request.form.get('color_hex', category.color_hex)
-            category.repeat_annually = bool(request.form.get('repeat_annually'))
-            category.display_celebration = bool(request.form.get('display_celebration'))
-            category.is_protected = bool(request.form.get('is_protected'))
+            category.repeat_annually = request.form.get('repeat_annually') == 'true'
+            category.display_celebration = request.form.get('display_celebration') == 'true'
+            category.is_protected = request.form.get('is_protected') == 'true'
             category.last_updated_by = request.remote_addr
             db.session.commit()
             return redirect(url_for('categories'))


### PR DESCRIPTION
### Motivation
- Fix incorrect boolean parsing in the category update endpoint where `bool(request.form.get(...))` would treat the string "false" as truthy and flip flags unintentionally, and align update behavior with create logic.

### Description
- Update `app/routes_categories.py` so `category.repeat_annually`, `category.display_celebration`, and `category.is_protected` are assigned using `request.form.get('...') == 'true'` instead of `bool(request.form.get('...'))`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975f99371d88325a7addb9035fb0c18)