### PR TITLE
Use get_entry_data sort option for admin default ordering

### DIFF
--- a/app/helpers.py
+++ b/app/helpers.py
@@ -144,17 +144,26 @@ def calculate_milestone_info(entry_date, display_date_obj, is_recurring):
     }
 
 
-def get_entry_data(db, category_filter=None, max_past_entries=None):
+def get_entry_data(db, category_filter=None, max_past_entries=None, sort_order='display_date'):
     """Returns formatted entries and categories data with complete category details for each entry.
     
     If max_past_entries is provided, only the most recent past entries up to that count will be included.
     For recurring events, calculates display_date based on current/next year occurrence.
+
+    sort_order values:
+      - 'display_date' (default): timeline-oriented display date sorting with past/future pivot
+      - 'created_desc': preserve DB order by newest created entry first
     """
     # Parse the category_filter if provided
     filter_categories = category_filter.split(',') if category_filter else None
 
     # Preload categories to avoid N+1 query issues
-    query = db.session.query(Entry).options(joinedload(Entry.category)).order_by(Entry.date)
+    query = db.session.query(Entry).options(joinedload(Entry.category))
+
+    if sort_order == 'created_desc':
+        query = query.order_by(Entry.id.desc())
+    else:
+        query = query.order_by(Entry.date)
     
     if filter_categories:
         # Filter entries based on the category names
@@ -175,21 +184,25 @@ def get_entry_data(db, category_filter=None, max_past_entries=None):
             milestone_info = calculate_milestone_info(entry_date, display_date_obj, entry.category.repeat_annually)
             entries_with_display.append((entry, entry_date, display_date_obj, milestone_info))
     
-    # Sort by display date
-    entries_with_display.sort(key=lambda x: x[2])
-    
-    # Determine the pivot: the first upcoming or current entry (based on display date)
-    pivot = next((i for i, (entry, entry_date, display_date_obj, milestone_info) in enumerate(entries_with_display) 
-                  if str(display_date_obj) >= today_str), len(entries_with_display))
-    
-    # Split past and upcoming entries. Limit past entries if max_past_entries is provided.
-    past_entries = entries_with_display[:pivot]
-    future_entries = entries_with_display[pivot:]
-    if max_past_entries is not None:
-        past_entries = past_entries[-max_past_entries:]
-    filtered_entries = past_entries + future_entries
-    # The pivot for the filtered list is now the count of past entries kept
-    filtered_pivot = len(past_entries)
+    if sort_order == 'created_desc':
+        filtered_entries = entries_with_display
+        filtered_pivot = 0
+    else:
+        # Sort by display date
+        entries_with_display.sort(key=lambda x: x[2])
+
+        # Determine the pivot: the first upcoming or current entry (based on display date)
+        pivot = next((i for i, (entry, entry_date, display_date_obj, milestone_info) in enumerate(entries_with_display)
+                    if str(display_date_obj) >= today_str), len(entries_with_display))
+
+        # Split past and upcoming entries. Limit past entries if max_past_entries is provided.
+        past_entries = entries_with_display[:pivot]
+        future_entries = entries_with_display[pivot:]
+        if max_past_entries is not None:
+            past_entries = past_entries[-max_past_entries:]
+        filtered_entries = past_entries + future_entries
+        # The pivot for the filtered list is now the count of past entries kept
+        filtered_pivot = len(past_entries)
     
     formatted_entries = []
     for i, (entry, entry_date, display_date_obj, milestone_info) in enumerate(filtered_entries):

--- a/app/routes.py
+++ b/app/routes.py
@@ -110,7 +110,7 @@ def init_app(app, scheduler):
     @app.route('/', methods=['GET'])
     def index():
         """Display the main admin page."""
-        data = get_entry_data(db)
+        data = get_entry_data(db, sort_order='created_desc')
         return render_template('admin/index.html', entries=data['entries'], categories=data['categories'])
 
     @app.route('/create', methods=['POST'])

--- a/app/routes_quotes.py
+++ b/app/routes_quotes.py
@@ -152,7 +152,7 @@ def init_quote_routes(app):
 
     @app.route('/quotes/', methods=['GET'])
     def list_quotes():
-        quotes = Quote.query.all()
+        quotes = Quote.query.order_by(Quote.id.desc()).all()
         return render_template('admin/quotes.html', quotes=quotes)
 
     @app.route('/quotes/create', methods=['POST'])

--- a/app/static/admin/sort-table.js
+++ b/app/static/admin/sort-table.js
@@ -283,9 +283,25 @@ function sortRows(column, direction) {
     rows.forEach((row) => tbody.appendChild(row));
 }
 
+function restoreOriginalRowOrder() {
+    const table = getTable();
+    if (!table) {
+        return;
+    }
+
+    const tbody = table.tBodies[0];
+    const rows = Array.from(tbody.rows);
+
+    rows
+        .sort((rowA, rowB) => Number(rowA.dataset.initialOrder) - Number(rowB.dataset.initialOrder))
+        .forEach((row) => tbody.appendChild(row));
+}
+
 function applyState() {
     if (activeSortColumn !== null) {
         sortRows(activeSortColumn, activeSortDirection);
+    } else {
+        restoreOriginalRowOrder();
     }
 
     applySortIndicators();
@@ -457,7 +473,12 @@ function initializeFilterRow() {
         const config = getFilterConfig(label);
 
         if (config.type === 'none') {
-            filterCell.textContent = '—';
+            const resetButton = document.createElement('button');
+            resetButton.type = 'button';
+            resetButton.className = 'table-reset-button';
+            resetButton.textContent = 'Zurücksetzen';
+            resetButton.addEventListener('click', resetTableState);
+            filterCell.appendChild(resetButton);
         } else if (config.type === 'category') {
             filterCell.appendChild(createCategoryFilter(columnIndex));
         } else if (config.type === 'date') {
@@ -472,6 +493,40 @@ function initializeFilterRow() {
     });
 
     table.tHead.appendChild(filterRow);
+}
+
+function captureInitialRowOrder() {
+    const table = getTable();
+    if (!table) {
+        return;
+    }
+
+    Array.from(table.tBodies[0].rows).forEach((row, index) => {
+        if (!row.dataset.initialOrder) {
+            row.dataset.initialOrder = String(index);
+        }
+    });
+}
+
+function resetTableState(event) {
+    if (event) {
+        event.preventDefault();
+        event.stopPropagation();
+    }
+
+    activeSortColumn = null;
+    activeSortDirection = 'asc';
+    activeFilters = {};
+    localStorage.removeItem(getStorageKey());
+
+    const table = getTable();
+    const existingFilterRow = table && table.querySelector('thead tr.table-filters');
+    if (existingFilterRow) {
+        existingFilterRow.remove();
+    }
+
+    initializeFilterRow();
+    applyState();
 }
 
 function loadTableState() {
@@ -514,6 +569,7 @@ window.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
+    captureInitialRowOrder();
     loadTableState();
     initializeFilterRow();
     applyState();

--- a/app/static/admin/style.css
+++ b/app/static/admin/style.css
@@ -224,3 +224,15 @@ thead .table-filters .date-range-filter {
     grid-template-columns: 1fr;
     gap: 4px;
 }
+
+
+.table-reset-button {
+    width: 100%;
+    padding: 4px 6px;
+    font-size: 0.85rem;
+    background-color: #6c757d;
+}
+
+.table-reset-button:hover {
+    background-color: #5a6268;
+}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -210,3 +210,10 @@ def test_create_zip_with_missing_files(test_client):
             # Should not attempt to write non-existent files
             assert not zip_file_instance.write.called
 
+
+
+def test_get_entry_data_created_desc_sort_order(test_client: FlaskClient, init_database: None):
+    with test_client.application.app_context():
+        data = get_entry_data(db, sort_order='created_desc')
+        ids = [entry['id'] for entry in data['entries']]
+        assert ids == sorted(ids, reverse=True)


### PR DESCRIPTION
### Motivation
- Keep the admin listing logic consolidated by using the shared data helper instead of duplicating a direct DB query in the route. 
- Provide an easy way to render the admin list newest-first while preserving the default timeline behavior elsewhere.

### Description
- Add an optional `sort_order` parameter to `get_entry_data` with default `"display_date"` and a new `"created_desc"` mode to order by `Entry.id.desc()` and preserve DB order. 
- When `sort_order == 'created_desc'` the helper skips the timeline pivot/slicing and returns entries in DB order, otherwise the existing display-date pivot logic remains unchanged. 
- Update the admin root route to call `get_entry_data(db, sort_order='created_desc')` so admin shows newest-created entries first. 
- Add `test_get_entry_data_created_desc_sort_order` to `tests/test_helpers.py` to assert entries are returned in descending `id` order.

### Testing
- Ran `pytest -q` and all tests passed with the new test included (`79 passed, 2 warnings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999081b34f48325bd006c662320bb97)