### PR TITLE
Add HTTP request collections for REST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ Below are the available API endpoints with their respective usage:
   - **POST** `/purge-old-entries`
   - Deletes all entries where the date is in the past and the category is not marked as protected.
 
+## HTTP Client Request Collections
+
+For convenient local API testing, ready-to-use `.http` request collections are provided in the `http/` folder:
+
+- `http/entries.http` for entry, category, maintenance, and utility endpoints
+- `http/quotes.http` for quote API and quote views
+- `http/grafana.http` for Grafana integration endpoints
+
+These files work with common REST client integrations (for example the VS Code REST Client extension or JetBrains HTTP Client).
+
 ## Quote Management
 
 The application includes full quote management functionality with both API endpoints and HTML views.

--- a/http/entries.http
+++ b/http/entries.http
@@ -1,0 +1,73 @@
+@baseUrl = http://127.0.0.1:5000
+@entryId = 1
+@categoryId = 1
+
+### Health-ish check (HTML admin page)
+GET {{baseUrl}}/
+
+### Timeline (HTML)
+GET {{baseUrl}}/timeline?timeline-height=100%&font-family=Arial&font-scale=1.2&categories=Birthday&max-past-entries=5
+
+### API data (JSON)
+GET {{baseUrl}}/api/data
+
+### Create entry (form data)
+POST {{baseUrl}}/create
+Content-Type: application/x-www-form-urlencoded
+
+# NOTE: category must already exist
+# date format: YYYY-MM-DD
+# optional fields: description, image_url, image_path
+# optional bool fields: yearly_repeat, is_past_event, hide_age, is_test_data, cancelled
+date=2030-12-24&title=Christmas%20Eve&category=Holiday&description=Family%20dinner
+
+### Update entry (form data)
+POST {{baseUrl}}/update/{{entryId}}
+Content-Type: application/x-www-form-urlencoded
+
+date=2030-12-25&title=Christmas%20Day&category=Holiday&description=Gifts
+
+### Delete entry
+POST {{baseUrl}}/delete/{{entryId}}
+
+### Toggle entry cancelled flag
+POST {{baseUrl}}/toggle_cancelled/{{entryId}}
+
+### Categories list + create category (GET/POST)
+GET {{baseUrl}}/categories
+
+### Create category
+POST {{baseUrl}}/categories
+Content-Type: application/x-www-form-urlencoded
+
+name=Holiday&color=%23ff0000&repeat_annually=true
+
+### Update category
+POST {{baseUrl}}/categories/update/{{categoryId}}
+Content-Type: application/x-www-form-urlencoded
+
+name=Holiday&color=%2300aa00&repeat_annually=true
+
+### Delete category
+POST {{baseUrl}}/categories/delete/{{categoryId}}
+
+### Batch import test data
+POST {{baseUrl}}/batch-import
+Content-Type: application/json
+
+< ./testdata.json
+
+### Export data zip
+GET {{baseUrl}}/export-data
+
+### Purge old entries
+POST {{baseUrl}}/purge-old-entries
+
+### GIF search (requires GIPHY_API_TOKEN)
+GET {{baseUrl}}/search_gifs?q=birthday
+
+### Build Giphy URL (requires GIPHY_API_TOKEN)
+GET {{baseUrl}}/get-giphy-url?q=birthday
+
+### Check Giphy integration
+GET {{baseUrl}}/check-giphy-enabled

--- a/http/grafana.http
+++ b/http/grafana.http
@@ -1,0 +1,60 @@
+@baseUrl = http://127.0.0.1:5000
+
+### Connection test
+GET {{baseUrl}}/grafana/
+
+### Search targets
+POST {{baseUrl}}/grafana/search
+Content-Type: application/json
+
+{}
+
+### Query timeseries for one or more categories
+POST {{baseUrl}}/grafana/query
+Content-Type: application/json
+
+{
+  "targets": [
+    {
+      "target": "Birthday",
+      "type": "timeserie"
+    },
+    {
+      "target": "Holiday",
+      "type": "timeserie"
+    }
+  ]
+}
+
+### Fetch annotations (query supports comma-separated categories)
+POST {{baseUrl}}/grafana/annotations
+Content-Type: application/json
+
+{
+  "annotation": {
+    "name": "Events",
+    "query": "Birthday,Holiday"
+  }
+}
+
+### Tag keys
+POST {{baseUrl}}/grafana/tag-keys
+Content-Type: application/json
+
+{}
+
+### Tag values by key = category
+POST {{baseUrl}}/grafana/tag-values
+Content-Type: application/json
+
+{
+  "key": "category"
+}
+
+### Tag values by key = date
+POST {{baseUrl}}/grafana/tag-values
+Content-Type: application/json
+
+{
+  "key": "date"
+}

--- a/http/quotes.http
+++ b/http/quotes.http
@@ -1,0 +1,38 @@
+@baseUrl = http://127.0.0.1:5000
+@quoteId = 1
+
+### List quotes (HTML)
+GET {{baseUrl}}/quotes/
+
+### Create quote
+POST {{baseUrl}}/quotes/create
+Content-Type: application/x-www-form-urlencoded
+
+text=Stay%20hungry%2C%20stay%20foolish.&author=Steve%20Jobs&category=inspiration&url=https%3A%2F%2Fexample.com
+
+### Update quote
+POST {{baseUrl}}/quotes/edit/{{quoteId}}
+Content-Type: application/x-www-form-urlencoded
+
+text=The%20best%20way%20to%20predict%20the%20future%20is%20to%20invent%20it.&author=Alan%20Kay&category=inspiration
+
+### Delete quote
+POST {{baseUrl}}/quotes/delete/{{quoteId}}
+
+### Random quote (JSON)
+GET {{baseUrl}}/quotes/random
+
+### Random quote filtered by categories + random color
+GET {{baseUrl}}/quotes/random?category=inspiration,motivation&color=true
+
+### Daily quote (JSON)
+GET {{baseUrl}}/quotes/daily
+
+### Daily quote filtered by categories + deterministic color
+GET {{baseUrl}}/quotes/daily?category=inspiration,motivation&color=true
+
+### Random quote view (HTML)
+GET {{baseUrl}}/quotes/random/view?category=inspiration&color=true
+
+### Daily quote view (HTML)
+GET {{baseUrl}}/quotes/daily/view?category=inspiration&color=true


### PR DESCRIPTION
### Motivation
- Provide ready-to-run HTTP client collections to simplify local testing and manual exploration of the app's REST endpoints. 
- Improve developer ergonomics for working with entries, categories, quotes and Grafana integration without needing to write ad-hoc curl commands.

### Description
- Add `http/entries.http` containing requests for entry CRUD, category CRUD, maintenance endpoints, and utility routes (Giphy/status). 
- Add `http/quotes.http` containing requests for quote management, random/daily JSON endpoints, and the HTML quote views. 
- Add `http/grafana.http` containing request templates for Grafana datasource endpoints (`search`, `query`, `annotations`, `tag-keys`, `tag-values`). 
- Update `README.md` to document the new `http/` folder and list the provided collections and usage with common REST client tools.

### Testing
- Run the test suite with `pytest -q`, which completed successfully with `80 passed` and `2 warnings`. 
- The new `.http` collections are static files only and do not affect application logic, and all automated tests passed after adding them.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69998df148a48325b59015ffb14366dd)