### PR TITLE
Migrate Grafana integration to Infinity data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,37 +345,37 @@ classDiagram
 
 ## Grafana Integration
 
-This application supports integration with Grafana through a Simple JSON Datasource, enabling Grafana to pull data for visualization purposes. Here are the endpoints provided for Grafana:
+This application integrates with Grafana using the **Infinity** data source plugin. Infinity can call JSON endpoints directly, so the Grafana API now exposes straightforward REST endpoints that return row-based JSON payloads.
 
-### Grafana Endpoint Descriptions
+### Grafana Infinity Endpoints
 
 - **Test Connection** (`GET /grafana/`)
-  - Confirms the data source connection is functional.
+  - Confirms the service is reachable.
 
-- **Search** (`POST /grafana/search`)
-  - Returns a list of categories that can be queried (e.g., 'cake', 'birthday').
+- **Categories** (`GET /grafana/infinity/categories`)
+  - Returns category rows for dashboard variables.
 
-- **Query** (`POST /grafana/query`)
-  - Retrieves timeseries data based on specified categories.
+- **Timeseries Rows** (`GET /grafana/infinity/timeseries`)
+  - Returns rows containing `category`, `date`, `timestamp`, and `count`.
+  - Optional query parameters: `category`, `from`, and `to` (ISO timestamps).
 
-- **Annotations** (`POST /grafana/annotations`)
-  - Delivers event annotations for graph overlays based on specific queries.
-
-- **Tag Keys** (`POST /grafana/tag-keys`)
-  - Provides tag keys for Grafana's ad hoc filtering capabilities.
-
-- **Tag Values** (`POST /grafana/tag-values`)
-  - Supplies values for the selected tag keys for further filtering.
+- **Annotations Rows** (`GET /grafana/infinity/annotations`)
+  - Returns rows containing `time`, `date`, `title`, `text`, and `category`.
+  - Optional query parameters: `categories` (comma-separated), `from`, and `to` (ISO timestamps).
 
 ### Example Usage
 
-Query Grafana for timeseries data in the 'cake' category using this `curl` command:
+Query Grafana Infinity for timeseries rows in the `Cake` category:
 
 ```bash
-curl -X POST http://127.0.0.1:5000/grafana/query -H "Content-Type: application/json" -d '{"targets":[{"target": "Cake", "type": "timeserie"}]}'
+curl "http://127.0.0.1:5000/grafana/infinity/timeseries?category=Cake"
 ```
 
-This command will return timeseries data points for the 'cake' category if such data exists. Ensure the Grafana Simple JSON Datasource plugin is installed and properly configured to interact with these endpoints.
+Query a date range using ISO timestamps:
+
+```bash
+curl "http://127.0.0.1:5000/grafana/infinity/timeseries?category=Cake&from=2024-01-01T00:00:00.000Z&to=2024-12-31T23:59:59.999Z"
+```
 
 ## Giphy Integration
 

--- a/app/routes_grafana.py
+++ b/app/routes_grafana.py
@@ -1,133 +1,131 @@
-from flask import request, jsonify, current_app
 from datetime import datetime
-from .models import Entry, Category
+
+from flask import current_app, jsonify, request
+
 from app import db
+from .models import Category, Entry
+
+
+DATE_FMT = "%Y-%m-%d"
+
+
+def _parse_iso_date(iso_date):
+    """Parse an ISO timestamp into a YYYY-MM-DD date string."""
+    if not iso_date:
+        return None
+
+    try:
+        return datetime.fromisoformat(iso_date.replace("Z", "+00:00")).date().isoformat()
+    except ValueError:
+        return None
+
+
+def _to_timestamp_ms(date_str):
+    return int(datetime.strptime(date_str, DATE_FMT).timestamp() * 1000)
+
 
 def init_grafana_routes(app):
-    """
-    Initialize Grafana routes for the Flask application.
-
-    :param app: Flask application instance
-    """
+    """Initialize Grafana routes for the Flask application."""
 
     @app.route('/grafana/')
     def grafana_test_connection():
-        """
-        Endpoint to test connection with Grafana.
-
-        :return: A message confirming connection establishment
-        """
+        """Health endpoint for Grafana connectivity checks."""
         return "Connection established", 200
 
-    @app.route('/grafana/search', methods=['POST'])
-    def grafana_search():
+    @app.route('/grafana/infinity/categories', methods=['GET'])
+    def grafana_infinity_categories():
+        """Return category rows for Grafana Infinity variable queries."""
+        try:
+            categories = db.session.query(Category.name).order_by(Category.name.asc()).all()
+            return jsonify([{"category": category.name} for category in categories])
+        except Exception as exc:
+            current_app.logger.error(f"Infinity categories failed: {exc}")
+            return jsonify({"error": "Failed to fetch categories"}), 500
+
+    @app.route('/grafana/infinity/timeseries', methods=['GET'])
+    def grafana_infinity_timeseries():
         """
-        Endpoint for Grafana to search available targets based on dynamic categories.
+        Return time-series rows for Grafana Infinity.
+
+        Query params:
+        - category: optional category name filter
+        - from: optional ISO datetime lower bound
+        - to: optional ISO datetime upper bound
         """
         try:
-            categories = db.session.query(Category.name).all()
-            targets = [category.name for category in categories]
-            return jsonify(targets)
-        except Exception as e:
-            current_app.logger.error(f"Search failed: {e}")
-            return jsonify({"error": "Search failed"}), 500
+            category_name = request.args.get('category')
+            start_date = _parse_iso_date(request.args.get('from'))
+            end_date = _parse_iso_date(request.args.get('to'))
 
-    @app.route('/grafana/query', methods=['POST'])
-    def grafana_query():
+            query = db.session.query(
+                Category.name.label('category'),
+                Entry.date.label('date'),
+                db.func.count(Entry.id).label('count'),
+            ).join(Category, Category.id == Entry.category_id)
+
+            if category_name:
+                query = query.filter(Category.name == category_name)
+            if start_date:
+                query = query.filter(Entry.date >= start_date)
+            if end_date:
+                query = query.filter(Entry.date <= end_date)
+
+            rows = query.group_by(Category.name, Entry.date).order_by(Entry.date.asc()).all()
+
+            return jsonify([
+                {
+                    "category": row.category,
+                    "date": row.date,
+                    "timestamp": _to_timestamp_ms(row.date),
+                    "count": row.count,
+                }
+                for row in rows
+            ])
+        except Exception as exc:
+            current_app.logger.error(f"Infinity timeseries failed: {exc}")
+            return jsonify({"error": "Failed to fetch timeseries"}), 500
+
+    @app.route('/grafana/infinity/annotations', methods=['GET'])
+    def grafana_infinity_annotations():
         """
-        Endpoint for Grafana to query data dynamically based on category names.
+        Return annotation rows for Grafana Infinity.
+
+        Query params:
+        - categories: optional comma-separated list of category names
+        - from: optional ISO datetime lower bound
+        - to: optional ISO datetime upper bound
         """
-        req = request.get_json()
         try:
-            response = []
-            for target in req['targets']:
-                category = db.session.query(Category).filter_by(name=target['target']).first()
-                if category and target['type'] == 'timeserie':
-                    data_points = db.session.query(
-                        Entry.date, 
-                        db.func.count(Entry.id).label('count')
-                    ).filter(Entry.category_id == category.id).group_by(Entry.date).all()
-    
-                    datapoints = [
-                        [count, datetime.strptime(date, '%Y-%m-%d').timestamp() * 1000]
-                        for date, count in data_points
-                    ]
-    
-                    response.append({
-                        "target": target['target'],
-                        "datapoints": datapoints
-                    })
-    
-            return jsonify(response)
-        except Exception as e:
-            current_app.logger.error(f"Query failed: {e}")
-            return jsonify({"error": "Query failed"}), 500
+            raw_categories = request.args.get('categories', '')
+            categories = [name.strip() for name in raw_categories.split(',') if name.strip()]
+            start_date = _parse_iso_date(request.args.get('from'))
+            end_date = _parse_iso_date(request.args.get('to'))
 
-    @app.route('/grafana/annotations', methods=['POST'])
-    def grafana_annotations():
-        """
-        Endpoint for Grafana to fetch annotations based on multiple category names.
-        """
-        req = request.get_json()
-        try:
-            annotations = []
-            query_categories = req['annotation']['query'].split(',')  # Split the query by commas
-            query_categories = [name.strip() for name in query_categories]  # Clean whitespace
-    
-            categories = db.session.query(Category).filter(Category.name.in_(query_categories)).all()
-            category_ids = [cat.id for cat in categories]  # List of category IDs from the query
-    
-            if category_ids:
-                entries = db.session.query(Entry).filter(Entry.category_id.in_(category_ids)).all()
-                for entry in entries:
-                    annotations.append({
-                        "annotation": req['annotation'],
-                        "time": datetime.strptime(entry.date, '%Y-%m-%d').timestamp() * 1000,
-                        "title": entry.title,
-                        "tags": [entry.category.name],
-                        "text": entry.description or ""
-                    })
-            return jsonify(annotations)
-        except Exception as e:
-            current_app.logger.error(f"Annotations failed: {e}")
-            return jsonify({"error": "Annotations failed"}), 500
+            query = db.session.query(Entry).join(Category, Category.id == Entry.category_id)
+            if categories:
+                query = query.filter(Category.name.in_(categories))
+            if start_date:
+                query = query.filter(Entry.date >= start_date)
+            if end_date:
+                query = query.filter(Entry.date <= end_date)
 
-    @app.route('/grafana/tag-keys', methods=['POST'])
-    def grafana_tag_keys():
-        """
-        Endpoint for Grafana to fetch tag keys.
+            entries = query.order_by(Entry.date.asc()).all()
 
-        :return: JSON list of tag keys
-        """
-        return jsonify([
-            {"type": "string", "text": "category"},
-            {"type": "string", "text": "date"}
-        ])
-
-    @app.route('/grafana/tag-values', methods=['POST'])
-    def grafana_tag_values():
-        """
-        Endpoint for Grafana to fetch tag values based on key dynamically.
-        """
-        req = request.get_json()
-        key = req['key']
-        try:
-            if key == "category":
-                categories = db.session.query(Category.name).distinct().all()
-                values = [{"text": category.name} for category in categories]
-            elif key == "date":
-                dates = db.session.query(Entry.date).distinct().all()
-                values = [{"text": date[0]} for date in dates]
-            else:
-                values = []
-            return jsonify(values)
-        except Exception as e:
-            current_app.logger.error(f"Failed to fetch tag values: {e}")
-            return jsonify({"error": "Failed to fetch tag values"}), 500
+            return jsonify([
+                {
+                    "time": _to_timestamp_ms(entry.date),
+                    "date": entry.date,
+                    "title": entry.title,
+                    "text": entry.description or "",
+                    "category": entry.category.name,
+                }
+                for entry in entries
+            ])
+        except Exception as exc:
+            current_app.logger.error(f"Infinity annotations failed: {exc}")
+            return jsonify({"error": "Failed to fetch annotations"}), 500
 
     app.add_url_rule('/grafana/', view_func=grafana_test_connection)
-    app.add_url_rule('/grafana/search', view_func=grafana_search, methods=['POST'])
-    app.add_url_rule('/grafana/query', view_func=grafana_query, methods=['POST'])
-    app.add_url_rule('/grafana/annotations', view_func=grafana_annotations, methods=['POST'])
-    app.add_url_rule('/grafana/tag-keys', view_func=grafana_tag_keys, methods=['POST'])
-    app.add_url_rule('/grafana/tag-values', view_func=grafana_tag_values, methods=['POST'])
+    app.add_url_rule('/grafana/infinity/categories', view_func=grafana_infinity_categories, methods=['GET'])
+    app.add_url_rule('/grafana/infinity/timeseries', view_func=grafana_infinity_timeseries, methods=['GET'])
+    app.add_url_rule('/grafana/infinity/annotations', view_func=grafana_infinity_annotations, methods=['GET'])

--- a/tests/test_routes_grafana.py
+++ b/tests/test_routes_grafana.py
@@ -1,198 +1,80 @@
 import json
-from app.models import Entry, Category
+
 from app import db
+from app.models import Category, Entry
+
 
 def test_grafana_test_connection(test_client):
-    """
-    Test the /grafana/ endpoint to ensure it returns a successful connection message.
-    """
     response = test_client.get('/grafana/')
     assert response.status_code == 200
     assert response.data == b"Connection established"
 
-def test_grafana_search(test_client, init_database):
-    """
-    Test the /grafana/search endpoint to ensure it returns a list of available categories.
-    """
 
-    response = test_client.post('/grafana/search')
+def test_grafana_infinity_categories(test_client, init_database):
+    response = test_client.get('/grafana/infinity/categories')
     assert response.status_code == 200
     data = json.loads(response.data)
     assert isinstance(data, list)
-    assert "Birthday" in data
-    assert "Release" in data
+    assert {"category": "Birthday"} in data
+    assert {"category": "Release"} in data
 
-def test_grafana_query(test_client, init_database):
-    """
-    Test the /grafana/query endpoint to ensure it returns the correct timeseries data.
-    """
-    # Set up category and entry for testing
+
+def test_grafana_infinity_timeseries(test_client, init_database):
     category = Category(name="Party", symbol="🎉", color_hex="#FFD700")
     db.session.add(category)
-    db.session.flush()  # to obtain the category id
+    db.session.flush()
     db.session.add(Entry(date="2021-05-20", category_id=category.id, title="John's Birthday", description="Birthday party"))
     db.session.commit()
 
-    query_data = {
-        "targets": [
-            {"target": "Party", "type": "timeserie"}
-        ]
-    }
-    response = test_client.post('/grafana/query', data=json.dumps(query_data), content_type='application/json')
+    response = test_client.get('/grafana/infinity/timeseries?category=Party')
     assert response.status_code == 200
     data = json.loads(response.data)
     assert isinstance(data, list)
     assert len(data) == 1
-    assert data[0]['target'] == "Party"
-    assert isinstance(data[0]['datapoints'], list)
+    assert data[0]['category'] == "Party"
+    assert data[0]['date'] == "2021-05-20"
+    assert data[0]['count'] == 1
+    assert isinstance(data[0]['timestamp'], int)
 
-def test_grafana_query_with_invalid_category(test_client, init_database):
-    """
-    Test the /grafana/query endpoint with an invalid category
-    """
-    query_data = {
-        "targets": [
-            {"target": "NonExistentCategory", "type": "timeserie"}
-        ]
-    }
-    response = test_client.post('/grafana/query', 
-                              data=json.dumps(query_data), 
-                              content_type='application/json')
-    assert response.status_code == 200
-    data = json.loads(response.data)
-    assert isinstance(data, list)
-    # For invalid category, expect empty list
-    assert len(data) == 0
 
-def test_grafana_query_with_date_range(test_client, init_database):
-    """
-    Test the /grafana/query endpoint with a specific date range
-    """
-    # Add test entries
+def test_grafana_infinity_timeseries_with_date_range(test_client, init_database):
     category = Category(name="Test", symbol="🔍", color_hex="#123456")
     db.session.add(category)
     db.session.flush()
 
-    dates = ["2023-01-01", "2023-06-01", "2024-01-01"]
-    for date_str in dates:
-        entry = Entry(
-            date=date_str,
-            category_id=category.id,
-            title=f"Test Entry {date_str}",
-            description="Test entry"
-        )
-        db.session.add(entry)
+    for date_str in ["2023-01-01", "2023-06-01", "2024-01-01"]:
+        db.session.add(Entry(date=date_str, category_id=category.id, title=f"Test Entry {date_str}", description="Test entry"))
     db.session.commit()
 
-    query_data = {
-        "range": {
-            "from": "2023-01-01T00:00:00.000Z",
-            "to": "2023-12-31T23:59:59.999Z"
-        },
-        "targets": [
-            {"target": "Test", "type": "timeserie"}
-        ]
-    }
-    
-    response = test_client.post('/grafana/query', 
-                              data=json.dumps(query_data), 
-                              content_type='application/json')
+    response = test_client.get(
+        '/grafana/infinity/timeseries?category=Test&from=2023-01-01T00:00:00.000Z&to=2023-12-31T23:59:59.999Z'
+    )
     assert response.status_code == 200
     data = json.loads(response.data)
-    
-    # Expect entries from within the time range and nearby
-    datapoints = data[0]['datapoints']
-    assert len([d for d in datapoints if d[1] is not None]) == 3
 
-def test_grafana_annotations(test_client, init_database):
-    """
-    Test the /grafana/annotations endpoint to ensure it returns the correct annotations based on the query.
-    """
+    assert len(data) == 2
+    assert {row['date'] for row in data} == {"2023-01-01", "2023-06-01"}
+
+
+def test_grafana_infinity_annotations(test_client, init_database):
     category = Category(name="Launch", symbol="🚀", color_hex="#FF6347")
     db.session.add(category)
     db.session.flush()
     db.session.add(Entry(date="2021-05-21", category_id=category.id, title="Product Launch", description="Launching a new product"))
     db.session.commit()
 
-    annotation_data = {
-        "annotation": {
-            "query": "Launch"
-        }
-    }
-    response = test_client.post('/grafana/annotations', data=json.dumps(annotation_data), content_type='application/json')
+    response = test_client.get('/grafana/infinity/annotations?categories=Launch')
     assert response.status_code == 200
     data = json.loads(response.data)
     assert isinstance(data, list)
     assert len(data) == 1
     assert data[0]['title'] == "Product Launch"
     assert data[0]['text'] == "Launching a new product"
+    assert data[0]['category'] == "Launch"
 
-def test_grafana_annotations_with_empty_query(test_client, init_database):
-    """
-    Test the /grafana/annotations endpoint with an empty query
-    """
-    annotation_data = {
-        "annotation": {
-            "query": ""
-        }
-    }
-    response = test_client.post('/grafana/annotations', 
-                              data=json.dumps(annotation_data), 
-                              content_type='application/json')
+
+def test_grafana_infinity_annotations_with_empty_query(test_client, init_database):
+    response = test_client.get('/grafana/infinity/annotations?categories=')
     assert response.status_code == 200
     data = json.loads(response.data)
     assert isinstance(data, list)
-    # Empty query returns empty list
-    assert len(data) == 0
-
-def test_grafana_tag_keys(test_client):
-    """
-    Test the /grafana/tag-keys endpoint to ensure it returns the correct tag keys.
-    """
-    response = test_client.post('/grafana/tag-keys')
-    assert response.status_code == 200
-    data = json.loads(response.data)
-    assert isinstance(data, list)
-    assert {"type": "string", "text": "category"} in data
-    assert {"type": "string", "text": "date"} in data
-
-def test_grafana_tag_values_category(test_client, init_database):
-    """
-    Test the /grafana/tag-values endpoint with key='category' to ensure it returns the correct category values.
-    """
-    request_data = {
-        "key": "category"
-    }
-    response = test_client.post('/grafana/tag-values', data=json.dumps(request_data), content_type='application/json')
-    assert response.status_code == 200
-    data = json.loads(response.data)
-    assert isinstance(data, list)
-    assert {"text": "Birthday"} in data
-
-def test_grafana_tag_values_date(test_client, init_database):
-    """
-    Test the /grafana/tag-values endpoint with key='date' to ensure it returns the correct date values.
-    """
-    request_data = {
-        "key": "date"
-    }
-    response = test_client.post('/grafana/tag-values', data=json.dumps(request_data), content_type='application/json')
-    assert response.status_code == 200
-    data = json.loads(response.data)
-    assert isinstance(data, list)
-    assert {"text": "2021-05-20"} in data
-
-def test_grafana_tag_values_invalid_key(test_client, init_database):
-    """
-    Test the /grafana/tag-values endpoint with an invalid key
-    """
-    request_data = {
-        "key": "invalid_key"
-    }
-    response = test_client.post('/grafana/tag-values', 
-                              data=json.dumps(request_data), 
-                              content_type='application/json')
-    assert response.status_code == 200
-    data = json.loads(response.data)
-    assert isinstance(data, list)
-    assert len(data) == 0  # Should return empty list for invalid key


### PR DESCRIPTION
### Motivation
- The legacy Grafana Simple JSON interfaces are being replaced with the Infinity datasource, which expects row-based REST endpoints and supports direct JSON queries from Grafana.
- Provide a simpler, more compatible API surface for dashboard variables, timeseries rows, and annotations with built-in ISO date filtering. 

### Description
- Replaced the Simple JSON routes with new Infinity-oriented endpoints under `/grafana/infinity/categories`, `/grafana/infinity/timeseries`, and `/grafana/infinity/annotations` while retaining `/grafana/` as a health endpoint.
- Implemented `_parse_iso_date` and `_to_timestamp_ms` helpers and added `DATE_FMT` to support ISO `from`/`to` query parameters and millisecond timestamps in responses.
- Changed responses to return row-based JSON objects (`category`, `date`, `timestamp`, `count` for timeseries; `time`, `date`, `title`, `text`, `category` for annotations) and applied server-side filtering and ordering.
- Updated tests in `tests/test_routes_grafana.py` and the README Grafana section to document the new Infinity endpoints and examples.

### Testing
- Ran the Grafana route tests with `pytest -q tests/test_routes_grafana.py` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69998dbe435c8325b96ee88e112e9eca)